### PR TITLE
Add support for projects in user accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const getData = () => {
 							}
 						}
 						owner {
-							... on Organization {
+							... on ProjectOwner {
 								projects( search: "${project}", first: 10, states: [OPEN] ) {
 									nodes {
 										id


### PR DESCRIPTION
**Change Organization to ProjectOwner interface**
By using the `ProjectOwner` interface instead of `Organization` the query is also able to search projects at user level.
https://developer.github.com/v4/interface/projectowner/#projectowner