### PR TITLE
Add option to only run rules for new cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Change these options in the workflow `.yml` file to meet your GitHub project nee
 | `project` | The name of the project | `Backlog` |
 | `column` | The column to create or move the card to | `Triage` |
 | `repo-token` | The personal access token | `${{ secrets.GITHUB_TOKEN }}` |
+| `on-new` | Only run rules if a card does not already exist in the project | `false` |
 
 
 ## Private repositories

--- a/index.js
+++ b/index.js
@@ -24,10 +24,11 @@ const getData = () => {
 		const token = core.getInput('repo-token');
 		const project = core.getInput('project');
 		const column = core.getInput('column');
+		const onNewOnly = core.getInput('on-new');
 
 		const {eventName, action, nodeId, url} = getData();
 
-		// Get the column ID  from searching for the project and card Id if it exists
+		// Get the column ID from searching for the project and card Id if it exists
 		const fetchColumnQuery = `query {
 			resource( url: "${url}" ) {
 				... on ${eventName === 'issues' ? 'Issue' : 'PullRequest'} {
@@ -101,7 +102,13 @@ const getData = () => {
 			[];
 		const cardId = cards.length > 0 ? cards[0].id : null;
 
-		// If a card already exists, move it to the column
+		// If a card already exists, and `on-new` is `true` terminate early
+		// as the card column should not be changed
+		if (cardId && onNewOnly === true) {
+			console.log(`🆗 Card already assigned to ${project}. No changes needed.`);
+			return
+		}
+
 		if (cardId) {
 			await Promise.all(
 				columns.map(column => octokit.graphql(`mutation {


### PR DESCRIPTION
Hey @alex-page, thanks for this action. It's been helpful for us in auto-assigning issues/PRs to get a cross-repo project overview.

One functionality I found myself needing that I couldn't easily solve with GitHub's conditional syntax was ability to not process a card if it already belonged to a project.
Otherwise we found ourselves fighting against the action which would end up "resetting" the card column.

Hope this is within scope of this project, otherwise no worries.
Let me know if you have any feedback/change-requests.

Cheers