### PR TITLE
Allow pull_request_target event

### DIFF
--- a/src/get-action-data.js
+++ b/src/get-action-data.js
@@ -5,7 +5,7 @@
  */
 const getActionData = githubContext => {
 	const {eventName, payload} = githubContext;
-	if (eventName !== 'pull_request' && eventName !== 'issues') {
+	if (eventName !== 'pull_request' && eventName !== 'pull_request_target' && eventName !== 'issues') {
 		throw new Error(`Only pull requests or issues allowed, received:\n${eventName}`);
 	}
 


### PR DESCRIPTION
@github released [improvements for fork and pull request workflows](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) which introduces a new `pull_request_target` event.

> In order to solve this, we’ve added a new `pull_request_target` event, which behaves in an almost identical way to the `pull_request` event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.