### PR TITLE
README: Switch master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To set up the action for local development and testing:
 
 1. Create a fork of the github-project-automation-plus
 2. Create a new repository with a project
-3. Add a workflow file that changes the `uses` to your forked repository: `uses: my-fork/github-project-automation-plus@master`
+3. Add a workflow file that changes the `uses` to your forked repository: `uses: my-fork/github-project-automation-plus@main`
 3. Make changes to your action and deploy them to GitHub
 
 


### PR DESCRIPTION
This project has switched to `main`.

Update the README instructions to match, as new forks will use the same name.