### PR TITLE
Add pull request review event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Change these options in the workflow `.yml` file to meet your GitHub project nee
 
 | Setting | Description | Values |
 | --- | --- | --- |
-| `on` | When the automation is ran | `issues` `pull_request` `issue_comment` |
-| `types` | The types of activity that will trigger a workflow run. | `opened`, `assigned`, `edited` |
+| `on` | When the automation is ran | `issues` `pull_request` `issue_comment` `pull_request_target` `pull_request_review` |
+| `types` | The types of activity that will trigger a workflow run. | `opened`, `assigned`, `edited`: [See GitHub docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request) for more |
 | `project` | The name of the project | `Backlog` |
 | `column` | The column to create or move the card to | `Triage` |
 | `repo-token` | The personal access token | `${{ secrets.GITHUB_TOKEN }}` |

--- a/__tests__/get-action-data.js
+++ b/__tests__/get-action-data.js
@@ -205,12 +205,12 @@ test('getActionData should return a formatted object from comment', t => {
 	});
 });
 
-test('getActionData should fail when eventName is not issues or pull_request', t => {
+test('getActionData should fail when eventName is not covered by action', t => {
 	const failingMockGithubContext = Object.assign({}, mockGithubContext);
 	const eventName = 'label';
 	failingMockGithubContext.eventName = eventName;
 
 	const error = t.throws(() => getActionData(failingMockGithubContext));
 
-	t.is(error.message, `Only pull requests, issues or comments allowed, received:\n${eventName}`);
+	t.is(error.message, `Only pull requests, reviews, issues, or comments allowed. Received:\n${eventName}`);
 });

--- a/src/get-action-data.js
+++ b/src/get-action-data.js
@@ -3,10 +3,18 @@
  *
  * @param {object} githubContext - The current issue or pull request data
  */
+const ACCEPTED_EVENT_TYPES = [
+	'pull_request',
+	'pull_request_target',
+	'pull_request_review',
+	'issues',
+	'issue_comment'
+];
+
 const getActionData = githubContext => {
 	const {eventName, payload} = githubContext;
-	if (eventName !== 'pull_request' && eventName !== 'pull_request_target' && eventName !== 'issues' && eventName !== 'issue_comment') {
-		throw new Error(`Only pull requests, issues or comments allowed, received:\n${eventName}`);
+	if (!ACCEPTED_EVENT_TYPES.includes(eventName)) {
+		throw new Error(`Only pull requests, reviews, issues, or comments allowed. Received:\n${eventName}`);
 	}
 
 	const githubData = eventName === 'issues' || eventName === 'issue_comment' ?


### PR DESCRIPTION
Wasn't able to test this locally as I couldn't get the action working, but it seems like a minor change that I expect is covered by existing tests.

[Schema for event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_review)

Closes #61 