### PR TITLE
Fix Issue Comment Error

### DIFF
--- a/src/generate-project-query.js
+++ b/src/generate-project-query.js
@@ -5,10 +5,10 @@
  * @param {string} eventName - The current event name
  * @param {string} project - The project to find
  */
-const projectQuery = (url, eventName, project) => (
-	`query {
+const projectQuery = (url, eventName, project) =>
+  `query {
 		resource( url: "${url}" ) {
-			... on ${eventName === 'issues' ? 'Issue' : 'PullRequest'} {
+			... on ${eventName.startsWith('issue') ? 'Issue' : 'PullRequest'} {
 				projectCards {
 					nodes {
 						id
@@ -51,7 +51,6 @@ const projectQuery = (url, eventName, project) => (
 				}
 			}
 		}
-	}`
-);
+	}`;
 
 module.exports = projectQuery;


### PR DESCRIPTION
## Description

Fixes an error where issue comments were picked up as pull requests. This caused the action to break. To fix this, I switched it from checking if the event name was issues to checking if the event name started with issue, thanks to a suggestion @andylolz. In my testing, the issue comment event now works.

## Closes

- Closes #69 