### PR TITLE
Use Node.js 16 as the action runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: "update"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'cpu'


### PR DESCRIPTION
Fixes #82

This PR updates the Node.js runtime to `node16` from the previous `node12` as the older runtime has been deprecated.